### PR TITLE
Update CDK version

### DIFF
--- a/content/capacity_providers/software.md
+++ b/content/capacity_providers/software.md
@@ -13,7 +13,7 @@ In the Cloud9 workspace, run the following commands:
 sudo yum -y install jq nodejs python36
 
 # Setting CDK Version
-export AWS_CDK_VERSION="1.41.0"
+export AWS_CDK_VERSION="1.171.0"
 
 # Install aws-cdk
 npm install -g --force aws-cdk@$AWS_CDK_VERSION


### PR DESCRIPTION
In order to avoid deployment fail when creating lambda functions with python 3.6 ( for CDK v1.41.0).